### PR TITLE
Feat: Add readNvItem and writeNvItem commands for single NV items

### DIFF
--- a/EfsTools/CommandLineOptions/NvItemFormat.cs
+++ b/EfsTools/CommandLineOptions/NvItemFormat.cs
@@ -1,0 +1,9 @@
+namespace EfsTools.CommandLineOptions
+{
+    internal enum NvItemFormat
+    {
+        Raw,
+        Hex,
+        Dec
+    }
+}

--- a/EfsTools/CommandLineOptions/ReadNvItemOptions.cs
+++ b/EfsTools/CommandLineOptions/ReadNvItemOptions.cs
@@ -1,0 +1,17 @@
+using CommandLine;
+
+namespace EfsTools.CommandLineOptions
+{
+    [Verb("readNvItem", HelpText = "Read single NV item.")]
+    internal class ReadNvItemOptions
+    {
+        [Option('i', "itemId", Required = true, HelpText = "NV item ID.")]
+        public ushort ItemId { get; set; }
+
+        [Option('o', "outComputerFilePath", Required = false, HelpText = "Output computer file path. If not specified, output will be sent to the console.")]
+        public string OutComputerFilePath { get; set; }
+
+        [Option('f', "format", Required = false, Default = NvItemFormat.Raw, HelpText = "Output format (Raw, Hex, Dec). Default is Raw. 'Raw' format is not supported for console output and will default to 'Hex'.")]
+        public NvItemFormat Format { get; set; }
+    }
+}

--- a/EfsTools/CommandLineOptions/WriteNvItemOptions.cs
+++ b/EfsTools/CommandLineOptions/WriteNvItemOptions.cs
@@ -1,0 +1,20 @@
+using CommandLine;
+
+namespace EfsTools.CommandLineOptions
+{
+    [Verb("writeNvItem", HelpText = "Write single NV item from a file or a string payload.")]
+    internal class WriteNvItemOptions
+    {
+        [Option('i', "itemId", Required = true, HelpText = "NV item ID.")]
+        public ushort ItemId { get; set; }
+
+        [Option('c', "inComputerFilePath", Required = false, HelpText = "Input computer file path.", SetName = "file")]
+        public string InComputerFilePath { get; set; }
+        
+        [Option('p', "payload", Required = false, HelpText = "Input payload string (for Hex or Dec formats).", SetName = "payload")]
+        public string Payload { get; set; }
+
+        [Option('f', "format", Required = false, Default = NvItemFormat.Raw, HelpText = "Input format (Raw, Hex, Dec). Default is Raw. 'Raw' format is not supported for payload input.")]
+        public NvItemFormat Format { get; set; }
+    }
+}

--- a/EfsTools/Program.cs
+++ b/EfsTools/Program.cs
@@ -44,6 +44,8 @@ namespace EfsTools
                         typeof(GetModemConfigOptions),
                         typeof(SetModemConfigOptions),
                         typeof(ExtractMbnOptions),
+                        typeof(ReadNvItemOptions),
+                        typeof(WriteNvItemOptions),
                         typeof(StartWebDavServerOptions),
                         typeof(GetLogsOptions)
                     );
@@ -78,6 +80,10 @@ namespace EfsTools
                         tools.ExtractMbn(opts.InputMbnFilePath, opts.OutputComputerDirectoryPath, opts.NoExtraData));
                     cmd.WithParsed<GetLogsOptions>(opts =>
                         tools.GetLog(opts.MessageMask, opts.LogMask, opts.Verbose));
+                    cmd.WithParsed<ReadNvItemOptions>(opts =>
+                        tools.ReadNvItem(opts.ItemId, opts.OutComputerFilePath, opts.Format));
+                    cmd.WithParsed<WriteNvItemOptions>(opts =>
+                        tools.WriteNvItem(opts.ItemId, opts.InComputerFilePath, opts.Payload, opts.Format));
                     cmd.WithParsed<StartWebDavServerOptions>(opts =>
                         tools.StartWebDavServer(opts.Port, opts.LogLevel, opts.ReadOnly != 0));
                     cmd.WithNotParsed(errors => { });

--- a/EfsTools/Utils/ParseUtils.cs
+++ b/EfsTools/Utils/ParseUtils.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace EfsTools.Utils
+{
+    internal static class ParseUtils
+    {
+        public static byte[] ParseHexString(string hex)
+        {
+            hex = Regex.Replace(hex, @"\s+", "");
+            if (hex.Length % 2 != 0)
+            {
+                throw new ArgumentException("Hex string must have an even number of characters.");
+            }
+
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
+        }
+
+        public static byte[] ParseDecString(string dec)
+        {
+            return dec.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                      .Select(byte.Parse)
+                      .ToArray();
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces two new commands, `readNvItem` and `writeNvItem`, to enable direct reading and writing of individual NV items without needing to process entire directories or modem configuration files every time.

#### New Commands:

**1. `readNvItem`**

Reads a single NV item from the device.

**Options:**
*   `-i, --itemId` (Required): The ID of the NV item to read.
*   `-o, --outComputerFilePath` (Optional): Path to save the output file. If omitted, the output is printed to the console.
*   `-f, --format` (Optional): The output format. Can be `Raw`, `Hex`, or `Dec`. Defaults to `Raw` for files and `Hex` for console output.

**Examples:**
```sh
# Read NV item 441 and print its content as a hex string to the console
EfsTools.exe readNvItem -i 441 

# Read NV item 441 and save it as a raw binary file
EfsTools.exe readNvItem -i 441 -o lock_code.bin

# Read NV item 441 and save it as a hex string in a text file
EfsTools.exe readNvItem -i 441 -o lock_code.txt -f Hex
```

**2. `writeNvItem`**

Writes data to a single NV item on the device.

**Options:**
*   `-i, --itemId` (Required): The ID of the NV item to write.
*   `-c, --inComputerFilePath` (Optional): The input file containing the data to write.
*   `-p, --payload` (Optional): A string containing the data to write. (Use quotes for strings with spaces).
*   `-f, --format` (Optional): The format of the input data. Can be `Raw`, `Hex`, or `Dec`. Defaults to `Raw`. `Raw` format is only valid for file inputs.

**Examples:**
```sh
# Write to NV item 441 from a raw binary file
EfsTools.exe writeNvItem -i 441 -c lock_code.bin

# Write to NV item 441 from a hex string in a text file
EfsTools.exe writeNvItem -i 441 -c lock_code.txt -f Hex

# Write to NV item 441 using a hex payload from the command line
EfsTools.exe writeNvItem -i 441 -p "31 32 33 34 00 00 00 00" -f Hex

# Write to NV item 441 using a decimal payload from the command line
EfsTools.exe writeNvItem -i 441 -p "49 50 51 52 0 0 0 0" -f Dec
```